### PR TITLE
Webpack cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.2.3](https://github.com/jfallaire/generator-ps-boilerplate-project/compare/v2.2.2...v2.2.3) (2019-09-06)
+
+
+### Bug Fixes
+
+* add empty npmignore to avoid missing gitignore ([cdca5a3](https://github.com/jfallaire/generator-ps-boilerplate-project/commit/cdca5a3))
+
 ## [2.2.2](https://github.com/jfallaire/generator-ps-boilerplate-project/compare/v2.2.1...v2.2.2) (2019-09-04)
 
 

--- a/generators/salesforce/templates/package.json
+++ b/generators/salesforce/templates/package.json
@@ -11,13 +11,9 @@
         "@commitlint/cli": "^7.6.0",
         "@commitlint/config-conventional": "^7.6.0",
         "@salesforce-ux/design-system": "^2.8.3",
-        "@semantic-release/changelog": "^3.0.2",
-        "@semantic-release/commit-analyzer": "^6.1.0",
-        "@semantic-release/git": "^7.0.8",
-        "@semantic-release/npm": "^5.1.7",
-        "@semantic-release/release-notes-generator": "^7.1.4",
         "@types/jasmine": "^3.3.12",
         "@types/underscore": "^1.8.14",
+        "autoprefixer": "^9.7.4",
         "clean-webpack-plugin": "^2.0.2",
         "commitizen": "^3.1.1",
         "coveo-search-ui": "2.5652.11",
@@ -45,6 +41,7 @@
         "mini-css-extract-plugin": "^0.6.0",
         "node-sass": "^4.12.0",
         "optimize-css-assets-webpack-plugin": "^5.0.1",
+        "postcss-loader": "^3.0.0",
         "puppeteer": "^1.16.0",
         "sass-loader": "^7.1.0",
         "semantic-release": "^15.13.12",
@@ -87,15 +84,4 @@
         "commitizen": {
             "path": "cz-conventional-changelog"
         }
-    },
-    "release": {
-        "branch": "master",
-        "plugins": [
-            "@semantic-release/commit-analyzer",
-            "@semantic-release/release-notes-generator",
-            "@semantic-release/changelog",
-            "@semantic-release/npm",
-            "@semantic-release/git"
-        ]
-    }
 }

--- a/generators/salesforce/templates/webpack.prod.config.js
+++ b/generators/salesforce/templates/webpack.prod.config.js
@@ -45,7 +45,14 @@ module.exports = merge(common, {
             }
           },
           'css-loader',
-          'sass-loader'
+          'sass-loader',
+          {
+            loader: 'postcss-loader',
+            options: {
+              ident: 'postcss',
+              plugins: [require('autoprefixer')({})]
+            }
+          }
         ]
       }
     ]

--- a/generators/simple/templates/package.json
+++ b/generators/simple/templates/package.json
@@ -11,13 +11,9 @@
         "@commitlint/cli": "^7.6.0",
         "@commitlint/config-conventional": "^7.6.0",
         "@salesforce-ux/design-system": "^2.8.3",
-        "@semantic-release/changelog": "^3.0.2",
-        "@semantic-release/commit-analyzer": "^6.1.0",
-        "@semantic-release/git": "^7.0.8",
-        "@semantic-release/npm": "^5.1.7",
-        "@semantic-release/release-notes-generator": "^7.1.4",
         "@types/jasmine": "^3.3.12",
         "@types/underscore": "^1.8.14",
+        "autoprefixer": "^9.7.4",
         "clean-webpack-plugin": "^2.0.2",
         "commitizen": "^3.1.1",
         "coveo-search-ui": "2.5652.11",
@@ -38,6 +34,7 @@
         "mini-css-extract-plugin": "^0.6.0",
         "node-sass": "^4.12.0",
         "optimize-css-assets-webpack-plugin": "^5.0.1",
+        "postcss-loader": "^3.0.0",
         "puppeteer": "^1.16.0",
         "sass-loader": "^7.1.0",
         "semantic-release": "^15.13.12",
@@ -77,15 +74,5 @@
         "commitizen": {
             "path": "cz-conventional-changelog"
         }
-    },
-    "release": {
-        "branch": "master",
-        "plugins": [
-            "@semantic-release/commit-analyzer",
-            "@semantic-release/release-notes-generator",
-            "@semantic-release/changelog",
-            "@semantic-release/npm",
-            "@semantic-release/git"
-        ]
     }
 }

--- a/generators/simple/templates/webpack.prod.config.js
+++ b/generators/simple/templates/webpack.prod.config.js
@@ -38,7 +38,14 @@ module.exports = merge(common, {
             }
           },
           'css-loader',
-          'sass-loader'
+          'sass-loader',
+          {
+            loader: 'postcss-loader',
+            options: {
+              ident: 'postcss',
+              plugins: [require('autoprefixer')({})]
+            }
+          }
         ]
       }
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-ps-boilerplate-project",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-ps-boilerplate-project",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Scaffolds out a template directory structure to help out CoveoPS folks when starting off a new project for a customer.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
`@semantic-release/...` are no longer needed in the package.json. They are  included by default.

Also added a autoprefixer plugin for css. This will ensure the styling works with various browsers.
